### PR TITLE
embed migration/seed SQL into the binary, guard seeding to local/test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,11 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: fe/package-lock.json
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: setup go app
         run: |
           docker compose up -d
@@ -47,7 +51,7 @@ jobs:
           npx playwright install --with-deps
           npx playwright test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,12 @@ on:
 jobs:
   test:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    # Pinned (not ubuntu-latest): Playwright ^1.40.1's `--with-deps` package
+    # list predates Ubuntu 24.04 ("noble")'s package renames (libasound2 ->
+    # libasound2t64, libffi7/libx264-163 dropped), so it fails to install
+    # browser deps on 24.04. Revisit this pin if/when @playwright/test is
+    # upgraded to a version with noble support.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/be/Dockerfile.seeder
+++ b/be/Dockerfile.seeder
@@ -5,9 +5,6 @@ FROM golang:1.21 as builder
 WORKDIR /app
 
 COPY go.mod go.sum ./
-COPY /db /app/db
-
-RUN ls /app
 RUN go mod download
 
 # Copy the backend source code into the container
@@ -17,10 +14,10 @@ COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o mishis4x .
 
 # Use a small base image to run the application
-FROM alpine:latest  
+FROM alpine:latest
 WORKDIR /root/
 
 # Copy the compiled application from the builder stage
+# (migration + seed SQL is embedded in the binary via go:embed, see be/db/embed.go)
 COPY --from=builder /app/mishis4x .
-COPY --from=builder /app/db .
 

--- a/be/cmd/migrations.go
+++ b/be/cmd/migrations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	dbassets "example.com/mishis4x/db"
 	"example.com/mishis4x/persist"
 	"github.com/spf13/cobra"
 )
@@ -31,10 +32,15 @@ var migrationsCMD = &cobra.Command{
 		}
 
 		if direction != "" {
-			persist.RunMigrations(db, direction)
+			persist.RunMigrations(db, direction, dbassets.Files)
 		}
 		if seed {
-			persist.SeedDB(db)
+			// Seed data is fake fixture data (e.g. a test user) - never run it
+			// against a real environment's database.
+			if env != "local" && env != "test" {
+				log.Fatalf("refusing to seed data for env %q: seeding is only allowed for local/test", env)
+			}
+			persist.SeedDB(db, dbassets.Files)
 		}
 
 	},

--- a/be/db/embed.go
+++ b/be/db/embed.go
@@ -1,0 +1,11 @@
+package db
+
+import "embed"
+
+// Files embeds the migration and seed SQL into the compiled binary so the
+// migration runner works no matter where the binary is invoked from -
+// no dependency on the process's working directory or on a deploy step
+// copying this directory to the right relative path at runtime.
+//
+//go:embed migrations seeds
+var Files embed.FS

--- a/be/persist/migrations.go
+++ b/be/persist/migrations.go
@@ -2,29 +2,27 @@ package persist
 
 import (
 	"database/sql"
-	"io"
+	"embed"
+	"io/fs"
 	"log"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 )
 
-func RunMigrations(db *sql.DB, direction string) {
+func RunMigrations(db *sql.DB, direction string, files embed.FS) {
 	log.Printf("Running %s migrations", direction)
-	// todo figure out how to make this dynamic based on env
-	sqlFilesDir := "./migrations/up"
+	sqlFilesDir := "migrations/up"
 
 	if direction == "down" {
-		sqlFilesDir = "./migrations/down"
+		sqlFilesDir = "migrations/down"
 	}
 	fileNames := []string{}
-	err := filepath.Walk(sqlFilesDir, func(path string, info os.FileInfo, err error) error {
+	err := fs.WalkDir(files, sqlFilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			panic(err)
 		}
 
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".sql") {
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".sql") {
 			fileNames = append(fileNames, path)
 		}
 		return nil
@@ -38,7 +36,7 @@ func RunMigrations(db *sql.DB, direction string) {
 	}
 
 	for _, fileName := range fileNames {
-		err := executeSQLFile(db, fileName)
+		err := executeSQLFile(files, fileName, db)
 		if err != nil {
 			log.Printf("error executing %s: %v", fileName, err)
 		} else {
@@ -49,28 +47,27 @@ func RunMigrations(db *sql.DB, direction string) {
 	log.Println("Migrations ran successfully")
 }
 
-func SeedDB(db *sql.DB) {
+func SeedDB(db *sql.DB, files embed.FS) {
 	log.Println("Seeding database")
-	sqlFilesDir := "./seeds"
+	sqlFilesDir := "seeds"
 
 	fileNames := []string{}
-	err := filepath.Walk(sqlFilesDir, func(path string, info os.FileInfo, err error) error {
+	err := fs.WalkDir(files, sqlFilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			log.Panicf("failed reading file name: %s ",err)
-	
+			log.Panicf("failed reading file name: %s ", err)
 		}
 
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".sql") {
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".sql") {
 			fileNames = append(fileNames, path)
 		}
 		return nil
 	})
 	if err != nil {
-		log.Panicf("failed reading file names: %s ",err)
+		log.Panicf("failed reading file names: %s ", err)
 	}
 
 	for _, fileName := range fileNames {
-		err := executeSQLFile(db, fileName)
+		err := executeSQLFile(files, fileName, db)
 		if err != nil {
 			log.Printf("error executing %s: %v", fileName, err)
 		} else {
@@ -79,20 +76,15 @@ func SeedDB(db *sql.DB) {
 	}
 }
 
-func executeSQLFile(db *sql.DB, filePath string) error {
-	file, err := os.Open(filePath)
+func executeSQLFile(files embed.FS, filePath string, db *sql.DB) error {
+	content, err := files.ReadFile(filePath)
 	if err != nil {
-		log.Panicf("failed opening file: %s ",err)
+		log.Panicf("failed reading file: %s ", err)
 	}
-	sb := strings.Builder{}
-	_, err = io.Copy(&sb, file)
+
+	_, err = db.Exec(string(content))
 	if err != nil {
-		log.Panicf("failed copying file: %s ",err)
-	}
-	sql := sb.String()
-	_, err = db.Exec(sql)
-	if err != nil {
-		log.Panicf("failed executing file: %s ",err)
+		log.Panicf("failed executing file: %s ", err)
 	}
 
 	return nil


### PR DESCRIPTION
RunMigrations and SeedDB previously walked relative paths ("./migrations/up", "./seeds") on disk, which only worked when the process's working directory happened to line up with where those files were copied to (true inside Dockerfile.seeder's image by coincidence, false when running the migrations command directly, e.g. `cd be && go run main.go migrations ...`, since the real files live under be/db/).

Switch to go:embed (be/db/embed.go) so the SQL travels inside the compiled binary regardless of working directory or deploy layout. Dockerfile.seeder no longer needs to separately COPY the db/ directory into the runtime image.

Also add a guard so --seed true is refused outside local/test - seed data is fake fixture data and should never be run against a real database.

Verified with go build/go vet, a standalone embed.FS walk, and a full docker compose db + db-seeder run against real MySQL (clean migrate + seed).