### PR TITLE
add README, .env.example, fix Makefile's broken run_be target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 generate_types:
 	@cd be && go run main.go jobs --job generate-types
 	@mv ./be/types.ts ./fe/src/types.ts
+
+run_db:
+	@docker compose up db
+
 run_be:
-	@cd be && docker build -t mishis4x-be .
-	@docker run -p 8091:8091 -e DB_USERNAME=$(DB_USERNAME) -e DB_HOST=$(DB_HOST) -e DB_PASSWORD=$(DB_PASSWORD) -e  DB_NAME=$(DB_NAME) mishis4x-be
+	@cd be && go run main.go http --env local
+
+run_fe:
+	@cd fe && npm run dev
+
 run_migrations:
 	@cd be && go run main.go migrations --env ${ENV} --direction up --seed true
+
 run_down_migrations:
 	@cd be && go run main.go migrations --env ${ENV} --direction down

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# mishis4x
+
+A Go + React web app with cookie-session auth as its foundation, plus an
+in-progress matchmaking/lobby system. The backend serves the built
+frontend directly, so the whole thing ships as one binary/one image.
+
+- `be/` — Go backend. A single `cobra` CLI (`be http`, `be migrations`,
+  `be jobs`) built from `be/main.go`.
+- `fe/` — React + TypeScript frontend (Vite).
+- `compose.yaml` — local/CI orchestration (MySQL + a one-shot migration
+  job + the app).
+
+## Requirements
+
+- Go 1.21+
+- Node 20+
+- Docker + Docker Compose
+
+## Running it locally
+
+There are two ways to run this, for two different purposes.
+
+### 1. Full stack — closest to production, what CI runs
+
+```
+docker compose up --build
+```
+
+This builds and starts, in order: `db` (MySQL), `db-seeder` (runs
+migrations + seeds fixture data once, then exits), then `app` (the
+combined Go+React binary) on **http://localhost:8091**.
+
+Use this when you want to test the app as it'll actually run in
+production, or as the target for the Playwright e2e suite (`fe/tests`).
+
+Tear down with `docker compose down` (add `-v` to also wipe the MySQL
+data volume and start fully fresh next time).
+
+### 2. Fast iteration — hot reload, no rebuild loop
+
+Run each piece natively so changes reload instantly instead of round-
+tripping through a Docker build.
+
+```
+make run_db          # starts just MySQL via compose
+make run_migrations ENV=local   # migrate + seed it (first time only)
+make run_be           # go run main.go http --env local
+make run_fe           # vite dev server
+```
+
+Open **http://localhost:5173**. The Vite dev server proxies `/api/*` to
+the Go server on `:8091` (see `fe/vite.config.ts`), so both need to be
+running.
+
+Log in with the seeded test user: `test` / `test` (see
+`be/db/seeds/001_users_seed.sql`).
+
+## Environment variables
+
+`be/infra/envs/local/.env` is loaded automatically whenever a command
+runs with `--env local` (the default for every `be` subcommand). See
+`be/infra/envs/local/.env.example` for what's required. For any other
+`--env` (`test`, `prod`, ...), the same variables must be set as real
+environment variables instead — `NewDB` only reads a `.env` file for
+`local`.
+
+## Common tasks
+
+- Regenerate `fe/src/types.ts` from the Go API structs:
+  `make generate_types`
+- Run e2e tests (needs the full stack running — see above):
+  `cd fe && npm test`
+- Roll back migrations: `make run_down_migrations ENV=local`
+
+## Notes
+
+- `--seed true` is refused for any `--env` other than `local`/`test` —
+  seed data is fake fixture data and should never land in a real
+  database.
+- Migration/seed SQL is embedded into the `be` binary at build time
+  (`be/db/embed.go`), so the migration runner works the same regardless
+  of where or how it's invoked.

--- a/be/infra/envs/local/.env.example
+++ b/be/infra/envs/local/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env (same directory) and adjust if needed.
+#
+# Loaded automatically by be/persist/persist.go's NewDB() whenever a
+# command is run with --env local (the default). For any other --env
+# (test, prod, ...), these must be set as real environment variables
+# instead - NewDB only reads a .env file for "local".
+DB_USERNAME=root
+DB_PASSWORD=root_password
+DB_HOST=localhost:3306
+DB_NAME=mishis4x
+ENV=local


### PR DESCRIPTION
There was no documentation anywhere for how to actually run this project, and two competing/undocumented ways to run the backend existed: `docker compose up` (full stack) vs `make run_be` (a standalone `docker run` against be/Dockerfile, which never copies the frontend dist/ in and required DB_* to already be set as shell/make vars with no indication of that anywhere).

- README.md documents both real workflows: docker compose for the full stack (what CI runs), and a fast native-iteration loop for local dev.
- Makefile: run_be now runs `go run main.go http --env local` (reads be/infra/envs/local/.env automatically, no Docker rebuild per change). Added run_db (just the db service) and run_fe (vite dev server) so the fast-iteration loop has a make target per piece.
- be/infra/envs/local/.env.example documents the required vars next to the real (dummy-credentialed) .env, without needing to read persist.go.