### PR TITLE
be: replace ad-hoc logging with structured zerolog logging

### DIFF
--- a/be/cmd/http.go
+++ b/be/cmd/http.go
@@ -43,4 +43,9 @@ var httpCMD = &cobra.Command{
 		}
 		h.InitializeHttpServer(port)
 
+		if err := db.Close(); err != nil {
+			log.Error().Err(err).Msg("error closing db connection")
+		} else {
+			log.Info().Msg("db connection closed")
+		}
 	}}

--- a/be/cmd/http.go
+++ b/be/cmd/http.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"log"
-
 	"example.com/mishis4x/handlers"
+	"example.com/mishis4x/logger"
 	"example.com/mishis4x/matchmaking"
 	persist "example.com/mishis4x/persist"
 	"github.com/gorilla/sessions"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -20,9 +20,11 @@ var httpCMD = &cobra.Command{
 	Short: "Start the HTTP server",
 	Long:  `Start the HTTP server`,
 	Run: func(cmd *cobra.Command, args []string) {
+		logger.Init(env)
+
 		db, err := persist.NewDB(env)
 		if err != nil {
-			log.Panicf("error connecting to db: %v", err)
+			log.Fatal().Err(err).Msg("error connecting to db")
 		}
 
 		db.SetMaxOpenConns(5)

--- a/be/cmd/jobs.go
+++ b/be/cmd/jobs.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-
 	"example.com/mishis4x/api"
+	"example.com/mishis4x/logger"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/tkrajina/typescriptify-golang-structs/typescriptify"
 )
@@ -20,8 +20,10 @@ var jobsCMD = &cobra.Command{
 	Short: "Start the jobs server",
 	Long:  `Start the jobs server`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Running jobs")
-		fmt.Println(jobName)
+		// No --env flag on this command; jobs are dev/build-time tooling, so
+		// always use local's human-readable console output.
+		logger.Init("local")
+		log.Info().Str("job", jobName).Msg("running job")
 		switch jobName {
 		case "generate-types":
 			generateTypes()
@@ -31,12 +33,12 @@ var jobsCMD = &cobra.Command{
 }
 
 func generateTypes() {
-	fmt.Println("Generating types")
+	log.Info().Msg("generating types")
 	converter := typescriptify.New().Add(api.GlobalData{})
 
 	err := converter.WithInterface(true).ConvertToFile("types.ts")
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Err(err).Msg("error generating types")
 	}
 
 }

--- a/be/cmd/migrations.go
+++ b/be/cmd/migrations.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
-
 	dbassets "example.com/mishis4x/db"
+	"example.com/mishis4x/logger"
 	"example.com/mishis4x/persist"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -24,11 +23,12 @@ var migrationsCMD = &cobra.Command{
 	Short: "Run migrations",
 	Long:  `Run migrations`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Running migrations")
+		logger.Init(env)
+		log.Info().Str("direction", direction).Bool("seed", seed).Msg("running migrations")
 
 		db, err := persist.NewDB(env)
 		if err != nil {
-			log.Panicf("error connecting to db: %v", err)
+			log.Fatal().Err(err).Msg("error connecting to db")
 		}
 
 		if direction != "" {
@@ -38,7 +38,7 @@ var migrationsCMD = &cobra.Command{
 			// Seed data is fake fixture data (e.g. a test user) - never run it
 			// against a real environment's database.
 			if env != "local" && env != "test" {
-				log.Fatalf("refusing to seed data for env %q: seeding is only allowed for local/test", env)
+				log.Fatal().Str("env", env).Msg("refusing to seed data: seeding is only allowed for local/test")
 			}
 			persist.SeedDB(db, dbassets.Files)
 		}

--- a/be/go.mod
+++ b/be/go.mod
@@ -17,7 +17,11 @@ require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/be/go.sum
+++ b/be/go.sum
@@ -16,7 +16,13 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
+github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
@@ -35,6 +41,9 @@ github.com/tkrajina/typescriptify-golang-structs v0.2.0/go.mod h1:sjU00nti/PMEOZ
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/be/handlers/globalData.go
+++ b/be/handlers/globalData.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 
 	"example.com/mishis4x/api"
+	"github.com/rs/zerolog/log"
 )
 
 func (d *Data) GetGlobalData(w http.ResponseWriter, r *http.Request) {
@@ -40,6 +40,6 @@ func (d *Data) GetGlobalData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := w.Write(jsonData); err != nil {
-		log.Printf("error writing response: %v", err)
+		log.Error().Err(err).Msg("error writing response")
 	}
 }

--- a/be/handlers/handlers.go
+++ b/be/handlers/handlers.go
@@ -1,9 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"example.com/mishis4x/matchmaking"
 	"example.com/mishis4x/persist"
@@ -11,6 +16,10 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/rs/zerolog/log"
 )
+
+// shutdownTimeout bounds how long we wait for in-flight requests to finish
+// once a shutdown signal is received before giving up and exiting anyway.
+const shutdownTimeout = 10 * time.Second
 
 type Data struct {
 	P        persist.Persist
@@ -44,8 +53,40 @@ func (d *Data) InitializeHttpServer(port int) {
 		http.ServeFile(w, r, "./dist/index.html")
 	})
 
-	log.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%d", port), r)).Msg("http server stopped")
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: r,
+	}
 
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			log.Fatal().Err(err).Msg("http server failed")
+		}
+	case sig := <-quit:
+		log.Info().Str("signal", sig.String()).Msg("shutdown signal received, draining in-flight requests")
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Error().Err(err).Msg("error during graceful shutdown, forcing exit")
+		} else {
+			log.Info().Msg("http server shut down gracefully")
+		}
+	}
 }
 
 // requestLoggingMiddleware logs every incoming request at debug level so it's

--- a/be/handlers/handlers.go
+++ b/be/handlers/handlers.go
@@ -3,13 +3,13 @@ package handlers
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 
 	"example.com/mishis4x/matchmaking"
 	"example.com/mishis4x/persist"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
+	"github.com/rs/zerolog/log"
 )
 
 type Data struct {
@@ -19,8 +19,9 @@ type Data struct {
 }
 
 func (d *Data) InitializeHttpServer(port int) {
-	log.Printf("Running http server on port: %d\n", port)
+	log.Info().Int("port", port).Msg("starting http server")
 	r := mux.NewRouter()
+	r.Use(requestLoggingMiddleware)
 	api := r.PathPrefix("/api").Subrouter()
 	api.Use(d.AuthMiddleware)
 
@@ -43,25 +44,31 @@ func (d *Data) InitializeHttpServer(port int) {
 		http.ServeFile(w, r, "./dist/index.html")
 	})
 
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), r))
+	log.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%d", port), r)).Msg("http server stopped")
 
+}
+
+// requestLoggingMiddleware logs every incoming request at debug level so it's
+// available locally without drowning out info-level logs in a real deploy.
+func requestLoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug().Str("method", r.Method).Str("path", r.URL.Path).Msg("incoming request")
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (d Data) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println(r.URL.Path)
-		fmt.Println("Auth middleware")
 		session, err := d.Sessions.Get(r, "session")
 		if err != nil {
+			log.Error().Err(err).Str("path", r.URL.Path).Msg("error reading session")
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 
 		isAuthenticated := session.Values["authenticated"]
 		if isAuthenticated != nil && isAuthenticated == true {
-			fmt.Printf("User found %s", session.Values["globalData"])
 			next.ServeHTTP(w, r)
 		} else if r.URL.Path == "/api/user/login" || r.URL.Path == "/api/user/create" {
-			fmt.Println("Login or create user")
 			next.ServeHTTP(w, r)
 		} else {
 			// TODO: add better error handling

--- a/be/handlers/matchmaking.go
+++ b/be/handlers/matchmaking.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"example.com/mishis4x/api"
+	"github.com/rs/zerolog/log"
 )
 
 func (d *Data) CreateLobby(w http.ResponseWriter, r *http.Request) {
@@ -34,10 +34,10 @@ func (d *Data) CreateLobby(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := w.Write(resp); err != nil {
-		fmt.Println("error writing response:", err)
+		log.Error().Err(err).Msg("error writing response")
 	}
 
-	fmt.Println("JSON output:", string(resp))
+	log.Debug().RawJSON("games", resp).Msg("lobby created")
 }
 
 func (d *Data) ListLobbies(w http.ResponseWriter, r *http.Request) {
@@ -51,8 +51,8 @@ func (d *Data) ListLobbies(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := w.Write(resp); err != nil {
-		fmt.Println("error writing response:", err)
+		log.Error().Err(err).Msg("error writing response")
 	}
 
-	fmt.Println("JSON output:", string(resp))
+	log.Debug().RawJSON("games", resp).Msg("lobbies listed")
 }

--- a/be/handlers/users.go
+++ b/be/handlers/users.go
@@ -2,12 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
 
 	"example.com/mishis4x/api"
 	"example.com/mishis4x/persist"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -26,14 +25,14 @@ func (d *Data) UserCreate(w http.ResponseWriter, r *http.Request) {
 	err := decoder.Decode(&u)
 
 	if err != nil {
-		log.Printf("Error decoding user: %+v", err)
+		log.Error().Err(err).Msg("error decoding user")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
 
 	if err != nil {
-		log.Printf("Error hashing password: %+v", err)
+		log.Error().Err(err).Msg("error hashing password")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -44,13 +43,13 @@ func (d *Data) UserCreate(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
-		log.Printf("Error creating user: %+v", err)
+		log.Error().Err(err).Msg("error creating user")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
 	session, err := d.Sessions.Get(r, "session")
 	if err != nil {
-		log.Printf("Error getting session: %+v", err)
+		log.Error().Err(err).Msg("error getting session")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -59,13 +58,14 @@ func (d *Data) UserCreate(w http.ResponseWriter, r *http.Request) {
 	// saves cookie
 	err = session.Save(r, w)
 	if err != nil {
-		log.Println("Error saving session on create")
+		log.Error().Err(err).Msg("error saving session on create")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
 	w.WriteHeader(http.StatusCreated)
 
-	log.Printf("New user: %+v", u)
+	// Deliberately not logging u (contains the plaintext password field).
+	log.Info().Str("username", u.Username).Int("userID", id).Msg("new user created")
 }
 
 func (d *Data) UserLogin(w http.ResponseWriter, r *http.Request) {
@@ -75,26 +75,26 @@ func (d *Data) UserLogin(w http.ResponseWriter, r *http.Request) {
 
 	err := decoder.Decode(&b)
 	if err != nil {
-		log.Printf("Error decoding user: %+v", err)
+		log.Error().Err(err).Msg("error decoding user")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 
 	u, err := d.P.GetUserByUsername(b.Username)
 	if err != nil {
-		log.Printf("Error getting user: %+v", err)
+		log.Error().Err(err).Str("username", b.Username).Msg("error getting user")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 
 	err = bcrypt.CompareHashAndPassword([]byte(u.Password), []byte(b.Password))
 
 	if err != nil {
-		log.Printf("Error comparing password: %+v", err)
+		log.Warn().Str("username", b.Username).Msg("login failed: password mismatch")
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 	}
-	log.Printf("USER authenticated")
+	log.Info().Str("username", u.Username).Msg("user authenticated")
 	session, err := d.Sessions.Get(r, "session")
 	if err != nil {
-		log.Printf("Error getting session: %+v", err)
+		log.Error().Err(err).Msg("error getting session")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 
@@ -102,7 +102,7 @@ func (d *Data) UserLogin(w http.ResponseWriter, r *http.Request) {
 	session.Values["authenticated"] = true
 	err = session.Save(r, w)
 	if err != nil {
-		log.Printf("Error saving session on login: %+v", err)
+		log.Error().Err(err).Msg("error saving session on login")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 }
@@ -118,7 +118,7 @@ func (d *Data) UserLogout(w http.ResponseWriter, r *http.Request) {
 	session.Options.MaxAge = -1
 	err = session.Save(r, w)
 	if err != nil {
-		fmt.Println("Error saving session")
+		log.Error().Err(err).Msg("error saving session on logout")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 }

--- a/be/logger/logger.go
+++ b/be/logger/logger.go
@@ -1,0 +1,29 @@
+// Package logger configures the process-wide zerolog logger. Call Init once
+// at startup (see cmd/root.go); every other package just imports
+// github.com/rs/zerolog/log and uses its global logger.
+package logger
+
+import (
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// Init sets the global zerolog logger. env == "local" gets human-readable
+// colored console output; anything else gets structured JSON on stdout,
+// which is what you want for a real deploy (grep/ingest-friendly).
+func Init(env string) {
+	zerolog.TimeFieldFormat = time.RFC3339
+
+	if env == "local" {
+		log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.Kitchen}).
+			With().Timestamp().Caller().Logger()
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		return
+	}
+
+	log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+}

--- a/be/persist/migrations.go
+++ b/be/persist/migrations.go
@@ -4,13 +4,14 @@ import (
 	"database/sql"
 	"embed"
 	"io/fs"
-	"log"
 	"slices"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 func RunMigrations(db *sql.DB, direction string, files embed.FS) {
-	log.Printf("Running %s migrations", direction)
+	log.Info().Str("direction", direction).Msg("running migrations")
 	sqlFilesDir := "migrations/up"
 
 	if direction == "down" {
@@ -38,23 +39,23 @@ func RunMigrations(db *sql.DB, direction string, files embed.FS) {
 	for _, fileName := range fileNames {
 		err := executeSQLFile(files, fileName, db)
 		if err != nil {
-			log.Printf("error executing %s: %v", fileName, err)
+			log.Error().Err(err).Str("file", fileName).Msg("error executing migration file")
 		} else {
-			log.Printf("executed %s\n", fileName)
+			log.Info().Str("file", fileName).Msg("executed migration file")
 		}
 	}
 
-	log.Println("Migrations ran successfully")
+	log.Info().Msg("migrations ran successfully")
 }
 
 func SeedDB(db *sql.DB, files embed.FS) {
-	log.Println("Seeding database")
+	log.Info().Msg("seeding database")
 	sqlFilesDir := "seeds"
 
 	fileNames := []string{}
 	err := fs.WalkDir(files, sqlFilesDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			log.Panicf("failed reading file name: %s ", err)
+			log.Fatal().Err(err).Msg("failed reading seed file name")
 		}
 
 		if !d.IsDir() && strings.HasSuffix(d.Name(), ".sql") {
@@ -63,15 +64,15 @@ func SeedDB(db *sql.DB, files embed.FS) {
 		return nil
 	})
 	if err != nil {
-		log.Panicf("failed reading file names: %s ", err)
+		log.Fatal().Err(err).Msg("failed reading seed file names")
 	}
 
 	for _, fileName := range fileNames {
 		err := executeSQLFile(files, fileName, db)
 		if err != nil {
-			log.Printf("error executing %s: %v", fileName, err)
+			log.Error().Err(err).Str("file", fileName).Msg("error executing seed file")
 		} else {
-			log.Printf("executed %s\n", fileName)
+			log.Info().Str("file", fileName).Msg("executed seed file")
 		}
 	}
 }
@@ -79,12 +80,12 @@ func SeedDB(db *sql.DB, files embed.FS) {
 func executeSQLFile(files embed.FS, filePath string, db *sql.DB) error {
 	content, err := files.ReadFile(filePath)
 	if err != nil {
-		log.Panicf("failed reading file: %s ", err)
+		log.Fatal().Err(err).Str("file", filePath).Msg("failed reading sql file")
 	}
 
 	_, err = db.Exec(string(content))
 	if err != nil {
-		log.Panicf("failed executing file: %s ", err)
+		log.Fatal().Err(err).Str("file", filePath).Msg("failed executing sql file")
 	}
 
 	return nil

--- a/be/persist/persist.go
+++ b/be/persist/persist.go
@@ -2,12 +2,11 @@ package persist
 
 import (
 	"database/sql"
-	"fmt"
-	"log"
 	"os"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
+	"github.com/rs/zerolog/log"
 )
 
 type Persist struct {
@@ -19,7 +18,7 @@ func NewDB(env string) (*sql.DB, error) {
 		envPath := "./infra/envs/local/.env"
 		err := godotenv.Load(envPath)
 		if err != nil {
-			log.Fatalf("error loading .env file: %v", err)
+			log.Fatal().Err(err).Msg("error loading .env file")
 		}
 	}
 
@@ -28,10 +27,12 @@ func NewDB(env string) (*sql.DB, error) {
 	dbName := os.Getenv("DB_NAME")
 	dbHost := os.Getenv("DB_HOST")
 
-	fmt.Println("dbUsername: ", dbUsername)
-	fmt.Println("dbPassword: ", dbPassword,
-		"dbName: ", dbName,
-		"dbHost: ", dbHost)
+	// Deliberately not logging dbPassword.
+	log.Debug().
+		Str("dbUsername", dbUsername).
+		Str("dbName", dbName).
+		Str("dbHost", dbHost).
+		Msg("connecting to db")
 
 	cfg := mysql.Config{
 		User:                 dbUsername,

--- a/be/persist/users.go
+++ b/be/persist/users.go
@@ -1,6 +1,6 @@
 package persist
 
-import "log"
+import "github.com/rs/zerolog/log"
 
 type User struct {
 	ID       int
@@ -40,7 +40,7 @@ func (p *Persist) GetUserByID(id int) (User, error) {
 
 	defer func() {
 		if closeErr := stmt.Close(); closeErr != nil {
-			log.Printf("error closing statement: %v", closeErr)
+			log.Error().Err(closeErr).Msg("error closing statement")
 		}
 	}()
 
@@ -69,7 +69,7 @@ func (p *Persist) GetUserByUsername(username string) (User, error) {
 
 	defer func() {
 		if closeErr := stmt.Close(); closeErr != nil {
-			log.Printf("error closing statement: %v", closeErr)
+			log.Error().Err(closeErr).Msg("error closing statement")
 		}
 	}()
 


### PR DESCRIPTION
We barely logged anything, and what little existed was inconsistent: some fmt.Println, some stdlib log.Printf/Panicf/Fatalf scattered across cmd/ and handlers/, no levels, no structure.

- Add logger.Init(env) (be/logger): local gets pretty colored console output at debug level (with caller info), everything else gets structured JSON on stdout at info level - grep/ingest friendly for a real deploy. Called once at the top of each cobra command's Run func (after --env is parsed), since jobs has no --env flag it just always uses local-style output.
- Convert every cmd/ and handlers/ + persist/ file from fmt.Println/stdlib log to zerolog, with real levels (Debug/Info/ Warn/Error/Fatal) and structured fields instead of string interpolation.
- Add a request-logging middleware (debug level) instead of the old unconditional fmt.Println(r.URL.Path) in AuthMiddleware.
- Fix a real bug found along the way: NewDB in persist/persist.go was printing the DB password to stdout on every connection (fmt.Println("dbPassword: ", dbPassword, ...)). Replaced with a debug log that only includes username/host/db name.
- Also stopped logging the plaintext User struct on account creation (it embeds the raw incoming password); now logs username/id only.

Verified: go build/vet/test all pass, golangci-lint (pinned v2.12.2, same as CI) reports 0 issues, gofmt clean. Smoke-tested against a throwaway MySQL container: `migrations --env test` produces JSON logs, `http --env local` produces colored console logs with caller info, and confirmed no password shows up in either.