### PR TITLE
be: add startup, HTTP, and DB query timeouts

### DIFF
--- a/be/handlers/globalData.go
+++ b/be/handlers/globalData.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -17,7 +18,10 @@ func (d *Data) GetGlobalData(w http.ResponseWriter, r *http.Request) {
 
 	userID := session.Values["userID"]
 
-	user, err := d.P.GetUserByID(userID.(int))
+	ctx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
+	defer cancel()
+
+	user, err := d.P.GetUserByID(ctx, userID.(int))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}

--- a/be/handlers/handlers.go
+++ b/be/handlers/handlers.go
@@ -17,9 +17,24 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// shutdownTimeout bounds how long we wait for in-flight requests to finish
-// once a shutdown signal is received before giving up and exiting anyway.
-const shutdownTimeout = 10 * time.Second
+const (
+	// shutdownTimeout bounds how long we wait for in-flight requests to
+	// finish once a shutdown signal is received before giving up and
+	// exiting anyway.
+	shutdownTimeout = 10 * time.Second
+
+	// http.Server timeouts. None of these existed before, which meant a
+	// slow or hung client could hold a connection open indefinitely.
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 10 * time.Second
+	writeTimeout      = 10 * time.Second
+	idleTimeout       = 120 * time.Second
+
+	// dbQueryTimeout bounds how long any single DB call triggered by a
+	// request is allowed to take, so a hung DB can't hang the request (and
+	// the client) forever.
+	dbQueryTimeout = 5 * time.Second
+)
 
 type Data struct {
 	P        persist.Persist
@@ -54,8 +69,12 @@ func (d *Data) InitializeHttpServer(port int) {
 	})
 
 	srv := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: r,
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           r,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
 
 	serverErr := make(chan error, 1)

--- a/be/handlers/users.go
+++ b/be/handlers/users.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -36,7 +37,10 @@ func (d *Data) UserCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
-	id, err := d.P.CreateUser(persist.User{
+	ctx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
+	defer cancel()
+
+	id, err := d.P.CreateUser(ctx, persist.User{
 		Username: u.Username,
 		Password: string(hashedPassword),
 		Status:   u.Status,
@@ -79,7 +83,10 @@ func (d *Data) UserLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 
-	u, err := d.P.GetUserByUsername(b.Username)
+	ctx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
+	defer cancel()
+
+	u, err := d.P.GetUserByUsername(ctx, b.Username)
 	if err != nil {
 		log.Error().Err(err).Str("username", b.Username).Msg("error getting user")
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/be/persist/migrations.go
+++ b/be/persist/migrations.go
@@ -1,14 +1,22 @@
 package persist
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"io/fs"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
+
+// statementTimeout bounds how long a single migration/seed SQL file is
+// allowed to run. These run as a one-shot process at deploy time (see
+// cmd/migrations.go), not per-request, so this is generous compared to
+// request-scoped DB timeouts.
+const statementTimeout = 30 * time.Second
 
 func RunMigrations(db *sql.DB, direction string, files embed.FS) {
 	log.Info().Str("direction", direction).Msg("running migrations")
@@ -83,7 +91,10 @@ func executeSQLFile(files embed.FS, filePath string, db *sql.DB) error {
 		log.Fatal().Err(err).Str("file", filePath).Msg("failed reading sql file")
 	}
 
-	_, err = db.Exec(string(content))
+	ctx, cancel := context.WithTimeout(context.Background(), statementTimeout)
+	defer cancel()
+
+	_, err = db.ExecContext(ctx, string(content))
 	if err != nil {
 		log.Fatal().Err(err).Str("file", filePath).Msg("failed executing sql file")
 	}

--- a/be/persist/persist.go
+++ b/be/persist/persist.go
@@ -1,13 +1,21 @@
 package persist
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog/log"
 )
+
+// connectTimeout bounds how long we'll wait to confirm the DB is actually
+// reachable at startup. sql.Open never dials on its own - without this ping,
+// an unreachable DB would only surface on the first real query.
+const connectTimeout = 5 * time.Second
 
 type Persist struct {
 	DB *sql.DB
@@ -46,6 +54,13 @@ func NewDB(env string) (*sql.DB, error) {
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("pinging db: %w", err)
 	}
 
 	return db, nil

--- a/be/persist/users.go
+++ b/be/persist/users.go
@@ -1,6 +1,10 @@
 package persist
 
-import "github.com/rs/zerolog/log"
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+)
 
 type User struct {
 	ID       int
@@ -9,12 +13,12 @@ type User struct {
 	Status   string
 }
 
-func (p *Persist) CreateUser(u User) (int, error) {
+func (p *Persist) CreateUser(ctx context.Context, u User) (int, error) {
 	q := `
 		INSERT INTO users (username, status, password)
 		VALUES (?, ?, ?);
 	`
-	result, err := p.DB.Exec(q, u.Username, u.Status, u.Password)
+	result, err := p.DB.ExecContext(ctx, q, u.Username, u.Status, u.Password)
 	if err != nil {
 		return -1, err
 	}
@@ -27,13 +31,13 @@ func (p *Persist) CreateUser(u User) (int, error) {
 }
 
 // TODO combine both into a query function
-func (p *Persist) GetUserByID(id int) (User, error) {
+func (p *Persist) GetUserByID(ctx context.Context, id int) (User, error) {
 	q := `
 		SELECT id, username, status, password
 		FROM users
 		WHERE id = ?;
 	`
-	stmt, err := p.DB.Query(q, id)
+	stmt, err := p.DB.QueryContext(ctx, q, id)
 	if err != nil {
 		return User{}, err
 	}
@@ -56,13 +60,13 @@ func (p *Persist) GetUserByID(id int) (User, error) {
 	return u, nil
 }
 
-func (p *Persist) GetUserByUsername(username string) (User, error) {
+func (p *Persist) GetUserByUsername(ctx context.Context, username string) (User, error) {
 	q := `
 		SELECT username, status, password, id
 		FROM users
 		WHERE username = ?;
 	`
-	stmt, err := p.DB.Query(q, username)
+	stmt, err := p.DB.QueryContext(ctx, q, username)
 	if err != nil {
 		return User{}, err
 	}

--- a/be/persist/users_test.go
+++ b/be/persist/users_test.go
@@ -59,18 +59,18 @@ func TestCreateAndFetchUser(t *testing.T) {
 		_, _ = db.Exec("DELETE FROM users WHERE username = ?", username)
 	})
 
-	id, err := p.CreateUser(User{Username: username, Status: "active", Password: "hashedpw"})
+	id, err := p.CreateUser(t.Context(), User{Username: username, Status: "active", Password: "hashedpw"})
 	require.NoError(t, err)
 	require.Greater(t, id, 0)
 
-	byID, err := p.GetUserByID(id)
+	byID, err := p.GetUserByID(t.Context(), id)
 	require.NoError(t, err)
 	require.Equal(t, username, byID.Username)
 	require.Equal(t, "active", byID.Status)
 	require.Equal(t, "hashedpw", byID.Password)
 	require.Equal(t, id, byID.ID)
 
-	byUsername, err := p.GetUserByUsername(username)
+	byUsername, err := p.GetUserByUsername(t.Context(), username)
 	require.NoError(t, err)
 	require.Equal(t, byID, byUsername)
 }


### PR DESCRIPTION
No timeouts existed anywhere in the backend:

- sql.Open never actually dials, so an unreachable DB at boot only surfaced on the first real query instead of failing fast at startup.
- http.Server had no ReadTimeout/WriteTimeout/IdleTimeout/ ReadHeaderTimeout, so a slow or hung client could hold a connection open indefinitely.
- Every DB call used Query/Exec (not the Context variants), so even a request-level timeout wouldn't actually cancel a hung query - the goroutine would just keep running underneath.

Changes:
- persist.NewDB now does a PingContext with a 5s timeout right after connecting, so an unreachable DB fails the process immediately with a clear error instead of starting up in a broken state.
- http.Server gets ReadHeaderTimeout/ReadTimeout/WriteTimeout (5-10s) and IdleTimeout (120s).
- persist.Persist's CreateUser/GetUserByID/GetUserByUsername now take a context.Context and use ExecContext/QueryContext; request handlers derive it from r.Context() with a 5s dbQueryTimeout, so a hung DB can't hang a request forever.
- persist.executeSQLFile (migrations/seeds) gets a generous 30s per-statement timeout via ExecContext, since it's a one-shot startup process rather than a request path.
- users_test.go updated to the new context-taking signatures using t.Context().

Verified: go build/vet/test pass, golangci-lint (v2.12.2, matches CI) 0 issues, gofmt clean. Ran the real MySQL integration test against a throwaway container. Also proved the startup timeout actually bounds the connect attempt rather than just hoping: pointed DB_HOST at a black-holed (non-routable, RFC 5737 TEST-NET-1) address and confirmed the process failed after ~5.1s instead of hanging on the OS's much longer default TCP connect timeout.