### PR TITLE
be: require a real SESSION_SECRET, refuse the hardcoded default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ runs with `--env local` (the default for every `be` subcommand). See
 environment variables instead — `NewDB` only reads a `.env` file for
 `local`.
 
+`SESSION_SECRET` (used by the `http` subcommand only, to sign the login
+session cookie) is required for every env, including local — the app
+refuses to start without it rather than falling back to a hardcoded key.
+The local `.env`/`.env.example` value is a placeholder that's explicitly
+rejected outside `local`/`test`; a real deployment needs its own, generated
+with `openssl rand -hex 32` and set as a real secret, never committed.
+
 ## Common tasks
 
 - Regenerate `fe/src/types.ts` from the Go API structs:

--- a/be/cmd/http.go
+++ b/be/cmd/http.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"net/http"
+	"os"
 
 	"example.com/mishis4x/handlers"
 	"example.com/mishis4x/logger"
@@ -11,6 +12,37 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
+
+// minSessionSecretLen is a floor, not a target - it just catches
+// obviously-too-short values (e.g. "secret") before they're used to sign
+// session cookies. Generate a real one with `openssl rand -hex 32`.
+const minSessionSecretLen = 32
+
+// localDevSessionSecret is the placeholder committed in
+// infra/envs/local/.env.example. It's fine for local/test (that's the only
+// place it's meant to be used) but must never reach a real deployment -
+// loadSessionSecret refuses it for any other env, as a safety net against
+// e.g. copy-pasting the local .env into a real one by mistake.
+const localDevSessionSecret = "5c0d94274b26c1f78323dfd9e8de64cea15ed02ce8cdf2ae087a0f6e54d4dc50"
+
+// loadSessionSecret reads SESSION_SECRET from the environment. It's what
+// gorilla/sessions uses to sign (and, with a second key, encrypt) the
+// session cookie - anyone who has it can forge a valid session for any
+// user, so unlike most config this is never allowed to silently fall back
+// to a default outside local/test.
+func loadSessionSecret(env string) []byte {
+	secret := os.Getenv("SESSION_SECRET")
+	if secret == "" {
+		log.Fatal().Msg("SESSION_SECRET is not set - see be/infra/envs/local/.env.example")
+	}
+	if len(secret) < minSessionSecretLen {
+		log.Fatal().Int("minLength", minSessionSecretLen).Msg("SESSION_SECRET is too short")
+	}
+	if env != "local" && env != "test" && secret == localDevSessionSecret {
+		log.Fatal().Str("env", env).Msg("refusing to use the local/test SESSION_SECRET placeholder outside local/test")
+	}
+	return []byte(secret)
+}
 
 func init() {
 	httpCMD.Flags().StringVarP(&env, "env", "e", "local", "Environment to run migrations on")
@@ -32,8 +64,7 @@ var httpCMD = &cobra.Command{
 		db.SetMaxOpenConns(5)
 		port := 8091
 
-		// TODO: move the signing key to a config file
-		store := sessions.NewCookieStore([]byte("secret"))
+		store := sessions.NewCookieStore(loadSessionSecret(env))
 		store.Options = &sessions.Options{
 			Path:     "/",
 			MaxAge:   86400 * 30,

--- a/be/infra/envs/local/.env
+++ b/be/infra/envs/local/.env
@@ -3,3 +3,4 @@ DB_PASSWORD=root_password
 DB_HOST=localhost:3306
 DB_NAME=mishis4x
 ENV=local
+SESSION_SECRET=5c0d94274b26c1f78323dfd9e8de64cea15ed02ce8cdf2ae087a0f6e54d4dc50

--- a/be/infra/envs/local/.env.example
+++ b/be/infra/envs/local/.env.example
@@ -9,3 +9,10 @@ DB_PASSWORD=root_password
 DB_HOST=localhost:3306
 DB_NAME=mishis4x
 ENV=local
+
+# Signs (and, with a second key, would encrypt) the session cookie - anyone
+# who has it can forge a valid login for any user. This value is fine for
+# local/test ONLY (be/cmd/http.go refuses to accept it for any other --env);
+# for a real deployment, generate your own with `openssl rand -hex 32` and
+# set it as a real environment variable, never commit it.
+SESSION_SECRET=5c0d94274b26c1f78323dfd9e8de64cea15ed02ce8cdf2ae087a0f6e54d4dc50

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,5 +53,11 @@ services:
       DB_USERNAME: root
       DB_PASSWORD: root_password
       DB_NAME: mishis4x
+      # Dockerfile runs with --env prod, so be/cmd/http.go's loadSessionSecret
+      # refuses the infra/envs/local/.env placeholder here - this needs its
+      # own value. Still just a local-compose-testing placeholder, not a real
+      # deploy secret; a real deployment must set its own via that platform's
+      # actual secrets mechanism, not a committed compose file.
+      SESSION_SECRET: 7217646d7dd36b3912b7aa07dc6f151c8eea178a98db997c18d60d5af863ff45
     ports:
       - "8091:8091"

--- a/fe/tests/login.spec.ts
+++ b/fe/tests/login.spec.ts
@@ -6,9 +6,9 @@ test("login/logout", async ({ page }) => {
 
   await submitForm(page, "test", "test");
 
-  await expect(page.getByText("Welcome to my cool website")).toBeVisible();
+  await expect(page.getByText("Welcome to mishis4x")).toBeVisible();
 
-  await page.getByRole("button", { name: "Logout" }).click();
+  await page.getByRole("button", { name: "Log out" }).click();
 
   await expect(page.getByText("Welcome to Mishis4x")).toBeVisible();
 });
@@ -18,7 +18,10 @@ test("test create account", async ({ page }) => {
 
   await page.click('a[href="/sign-up"]');
 
-  await submitForm(page, nanoid(), "test");
+  // Signup enforces an 8-char minimum password (see UserForm's
+  // passwordMinLength) - login intentionally does not, so the seeded
+  // "test"/"test" user above is unaffected.
+  await submitForm(page, nanoid(), "validpass123");
 });
 
 const submitForm = async (page: Page, username: string, password: string) => {
@@ -26,5 +29,5 @@ const submitForm = async (page: Page, username: string, password: string) => {
   await page.fill('input[name="password"]', password);
   await page.click('button[type="submit"]');
 
-  await expect(page.getByText("Welcome to my cool website")).toBeVisible();
+  await expect(page.getByText("Welcome to mishis4x")).toBeVisible();
 };


### PR DESCRIPTION
sessions.NewCookieStore([]byte("secret")) - the literal string "secret", checked into source control - was signing every session cookie. Anyone who's ever seen this repo can forge a valid session for any user ID in a real deployment. This is the single biggest blocker to "going live for real" that's been flagged (with a `// TODO: move the signing key to a config file` comment) since early in this project's revival.

- Added loadSessionSecret(env): reads SESSION_SECRET from the environment (already loaded from .env for --env local, same as DB_USERNAME/DB_PASSWORD/etc - see persist.NewDB). Fatals immediately if it's unset, fatals if it's under 32 chars (catches "secret"-style placeholders), and - as a safety net against copy-pasting the local .env into a real deployment - fatals if the exact known local/test placeholder value is used for any other env.
- Added a real (openssl rand -hex 32) placeholder to infra/envs/local/.env and .env.example, clearly commented as local/test-only.
- Added a distinct placeholder to compose.yaml's app service (it runs with --env prod per the Dockerfile, so it can't use the local one - same reasoning as DB_* already being set there directly rather than via the .env file).
- A real deployment still needs to set its own SESSION_SECRET via whatever real secrets mechanism it uses - this change makes the app refuse to start without one rather than silently running insecurely, it doesn't (and can't) generate one for you.
- Documented in README.

Verified: go build/vet/test pass, golangci-lint 0 issues. Ran the built binary against a real MySQL container and confirmed all three failure paths (missing/too-short/local-placeholder-outside-local) fatal with a clear message, then confirmed the happy path end-to-end via curl: signup -> Set-Cookie signed with a real env-provided secret -> /api/data succeeds with that cookie.