### PR TITLE
auth hardening: server-side sessions, rate limiting, change-password

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ runs with `--env local` (the default for every `be` subcommand). See
 environment variables instead — `NewDB` only reads a `.env` file for
 `local`.
 
-`SESSION_SECRET` (used by the `http` subcommand only, to sign the login
-session cookie) is required for every env, including local — the app
-refuses to start without it rather than falling back to a hardcoded key.
-The local `.env`/`.env.example` value is a placeholder that's explicitly
-rejected outside `local`/`test`; a real deployment needs its own, generated
-with `openssl rand -hex 32` and set as a real secret, never committed.
+Sessions don't need a signing secret: login/signup issue a random opaque
+token (`persist.NewSessionToken`, 256 bits from `crypto/rand`) stored server-
+side in the `sessions` table, and the cookie only ever carries that token.
+There's nothing to sign, encrypt, or leak — the token's own randomness plus
+the server-side lookup is what authenticates a request, and logout deletes
+the row outright instead of just clearing a client-side cookie.
 
 ## Common tasks
 

--- a/be/cmd/http.go
+++ b/be/cmd/http.go
@@ -1,48 +1,19 @@
 package cmd
 
 import (
-	"net/http"
-	"os"
+	"time"
 
 	"example.com/mishis4x/handlers"
 	"example.com/mishis4x/logger"
 	"example.com/mishis4x/matchmaking"
 	persist "example.com/mishis4x/persist"
-	"github.com/gorilla/sessions"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
-// minSessionSecretLen is a floor, not a target - it just catches
-// obviously-too-short values (e.g. "secret") before they're used to sign
-// session cookies. Generate a real one with `openssl rand -hex 32`.
-const minSessionSecretLen = 32
-
-// localDevSessionSecret is the placeholder committed in
-// infra/envs/local/.env.example. It's fine for local/test (that's the only
-// place it's meant to be used) but must never reach a real deployment -
-// loadSessionSecret refuses it for any other env, as a safety net against
-// e.g. copy-pasting the local .env into a real one by mistake.
-const localDevSessionSecret = "5c0d94274b26c1f78323dfd9e8de64cea15ed02ce8cdf2ae087a0f6e54d4dc50"
-
-// loadSessionSecret reads SESSION_SECRET from the environment. It's what
-// gorilla/sessions uses to sign (and, with a second key, encrypt) the
-// session cookie - anyone who has it can forge a valid session for any
-// user, so unlike most config this is never allowed to silently fall back
-// to a default outside local/test.
-func loadSessionSecret(env string) []byte {
-	secret := os.Getenv("SESSION_SECRET")
-	if secret == "" {
-		log.Fatal().Msg("SESSION_SECRET is not set - see be/infra/envs/local/.env.example")
-	}
-	if len(secret) < minSessionSecretLen {
-		log.Fatal().Int("minLength", minSessionSecretLen).Msg("SESSION_SECRET is too short")
-	}
-	if env != "local" && env != "test" && secret == localDevSessionSecret {
-		log.Fatal().Str("env", env).Msg("refusing to use the local/test SESSION_SECRET placeholder outside local/test")
-	}
-	return []byte(secret)
-}
+// sessionTTL is how long a session stays valid (and how long the browser
+// keeps the cookie) after login/signup.
+const sessionTTL = 30 * 24 * time.Hour
 
 func init() {
 	httpCMD.Flags().StringVarP(&env, "env", "e", "local", "Environment to run migrations on")
@@ -64,31 +35,22 @@ var httpCMD = &cobra.Command{
 		db.SetMaxOpenConns(5)
 		port := 8091
 
-		store := sessions.NewCookieStore(loadSessionSecret(env))
-		store.Options = &sessions.Options{
-			Path:     "/",
-			MaxAge:   86400 * 30,
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			// gorilla/sessions defaults to Secure:true + SameSite=None, which
-			// browsers silently refuse to store outside HTTPS - that broke
-			// login entirely on local/test's plain HTTP. This app serves the
-			// frontend and API from the same origin (see CLAUDE.md), so
-			// SameSite=Lax is correct everywhere; only Secure needs to vary
-			// by env.
-			Secure: env != "local" && env != "test",
-		}
-
-		h := handlers.Data{
-			P: persist.Persist{
-				DB: db,
-			},
-			Lobby: &matchmaking.Lobby{
+		h := handlers.NewData(
+			persist.Persist{DB: db},
+			&matchmaking.Lobby{
 				Games:  []*matchmaking.Game{},
 				GameID: 1,
 			},
-			Sessions: store,
-		}
+			handlers.SessionCookieConfig{
+				Name: "session",
+				TTL:  sessionTTL,
+				// Sessions are opaque random tokens looked up server-side
+				// (see persist/sessions.go) - a browser will silently refuse
+				// to store a Secure cookie outside HTTPS, so this only turns
+				// on once we're not on local/test's plain HTTP.
+				Secure: env != "local" && env != "test",
+			},
+		)
 		h.InitializeHttpServer(port)
 
 		if err := db.Close(); err != nil {

--- a/be/db/migrations/down/11092023_5_remove_sessions_table.sql
+++ b/be/db/migrations/down/11092023_5_remove_sessions_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sessions;

--- a/be/db/migrations/up/11092023_5_add_sessions_table.sql
+++ b/be/db/migrations/up/11092023_5_add_sessions_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE sessions (
+    id VARCHAR(64) NOT NULL PRIMARY KEY,
+    user_id INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    INDEX idx_sessions_user_id (user_id),
+    INDEX idx_sessions_expires_at (expires_at)
+);

--- a/be/go.mod
+++ b/be/go.mod
@@ -5,8 +5,8 @@ go 1.26
 require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/gorilla/mux v1.8.1
-	github.com/gorilla/sessions v1.4.0
 	github.com/joho/godotenv v1.5.1
+	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.0
 	github.com/tkrajina/typescriptify-golang-structs v0.2.0
@@ -15,11 +15,9 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/be/go.sum
+++ b/be/go.sum
@@ -4,14 +4,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
 github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
-github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
-github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
-github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/be/handlers/globalData.go
+++ b/be/handlers/globalData.go
@@ -10,16 +10,12 @@ import (
 )
 
 func (d *Data) GetGlobalData(w http.ResponseWriter, r *http.Request) {
-	session, err := d.Sessions.Get(r, "session")
-	if err != nil {
-		log.Error().Err(err).Msg("error reading session")
-		writeJSONError(w, http.StatusBadRequest, "Invalid session.")
-		return
-	}
-
-	userID, ok := session.Values["userID"].(int)
+	userID, ok := userIDFromContext(r)
 	if !ok {
-		log.Error().Msg("session missing a valid userID")
+		// AuthMiddleware already gates this route, so this would mean a
+		// programming error (e.g. this handler wired up outside the
+		// authenticated subrouter), not a normal unauthenticated request.
+		log.Error().Msg("GetGlobalData called without an authenticated user in context")
 		writeJSONError(w, http.StatusUnauthorized, "You must be logged in.")
 		return
 	}

--- a/be/handlers/handlers.go
+++ b/be/handlers/handlers.go
@@ -14,7 +14,6 @@ import (
 	"example.com/mishis4x/matchmaking"
 	"example.com/mishis4x/persist"
 	"github.com/gorilla/mux"
-	"github.com/gorilla/sessions"
 	"github.com/rs/zerolog/log"
 )
 
@@ -37,10 +36,34 @@ const (
 	dbQueryTimeout = 5 * time.Second
 )
 
+// SessionCookieConfig holds the cookie-level settings for server-side
+// sessions - everything except the actual session data, which lives in the
+// DB (see persist.Session). There's no signing secret here: the cookie only
+// ever carries an opaque, high-entropy random token (persist.NewSessionToken),
+// and that token's own randomness is what makes it unguessable - a lookup
+// against the sessions table is the actual authentication check.
+type SessionCookieConfig struct {
+	Name   string
+	Secure bool
+	TTL    time.Duration
+}
+
 type Data struct {
-	P        persist.Persist
-	Lobby    *matchmaking.Lobby
-	Sessions *sessions.CookieStore
+	P            persist.Persist
+	Lobby        *matchmaking.Lobby
+	Sessions     SessionCookieConfig
+	LoginLimiter *loginLimiter
+}
+
+// NewData builds a Data ready to serve requests, wiring up anything with
+// its own internal state (currently just the login rate limiter).
+func NewData(p persist.Persist, lobby *matchmaking.Lobby, sessions SessionCookieConfig) *Data {
+	return &Data{
+		P:            p,
+		Lobby:        lobby,
+		Sessions:     sessions,
+		LoginLimiter: newLoginLimiter(),
+	}
 }
 
 func (d *Data) InitializeHttpServer(port int) {
@@ -56,6 +79,7 @@ func (d *Data) InitializeHttpServer(port int) {
 
 	// // Protected routes
 	api.HandleFunc("/logout", d.UserLogout)
+	api.HandleFunc("/user/password", d.ChangePassword).Methods("POST")
 	api.HandleFunc("/data", d.GetGlobalData)
 	api.HandleFunc("/lobbies", d.ListLobbies)
 	api.HandleFunc("/lobbies/create", d.CreateLobby)
@@ -118,19 +142,30 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// userIDContextKey is the request-context key AuthMiddleware attaches an
+// authenticated request's user ID under, once it's validated the session.
+type userIDContextKey struct{}
+
+func userIDFromContext(r *http.Request) (int, bool) {
+	id, ok := r.Context().Value(userIDContextKey{}).(int)
+	return id, ok
+}
+
 func (d Data) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		session, err := d.Sessions.Get(r, "session")
-		if err != nil {
-			log.Error().Err(err).Str("path", r.URL.Path).Msg("error reading session")
-			writeJSONError(w, http.StatusBadRequest, "Invalid session.")
-			return
-		}
+		if token := d.sessionToken(r); token != "" {
+			lookupCtx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
+			session, err := d.P.GetSession(lookupCtx, token)
+			cancel()
 
-		isAuthenticated, _ := session.Values["authenticated"].(bool)
-		if isAuthenticated {
-			next.ServeHTTP(w, r)
-			return
+			if err == nil {
+				ctx := context.WithValue(r.Context(), userIDContextKey{}, session.UserID)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+			if !errors.Is(err, persist.ErrSessionNotFound) {
+				log.Error().Err(err).Msg("error reading session")
+			}
 		}
 
 		if r.URL.Path == "/api/user/login" || r.URL.Path == "/api/user/create" {
@@ -140,6 +175,45 @@ func (d Data) AuthMiddleware(next http.Handler) http.Handler {
 
 		writeJSONError(w, http.StatusUnauthorized, "You must be logged in.")
 	})
+}
+
+// setSessionCookie sets the session cookie to token, using the app's
+// configured TTL/Secure settings.
+func (d Data) setSessionCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     d.Sessions.Name,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(d.Sessions.TTL.Seconds()),
+		HttpOnly: true,
+		Secure:   d.Sessions.Secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearSessionCookie tells the browser to drop the session cookie
+// immediately (MaxAge -1). Callers should also delete the corresponding row
+// via d.P.DeleteSession - clearing the cookie alone doesn't revoke it.
+func (d Data) clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     d.Sessions.Name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   d.Sessions.Secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// sessionToken reads the raw session cookie value from the request, or ""
+// if there isn't one.
+func (d Data) sessionToken(r *http.Request) string {
+	c, err := r.Cookie(d.Sessions.Name)
+	if err != nil {
+		return ""
+	}
+	return c.Value
 }
 
 // errorResponse is the JSON body returned by writeJSONError.

--- a/be/handlers/loginLimiter.go
+++ b/be/handlers/loginLimiter.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	maxFailedLoginAttempts = 5
+	loginLockoutWindow     = 15 * time.Minute
+	loginLockoutDuration   = 5 * time.Minute
+)
+
+type loginAttempt struct {
+	count       int
+	windowStart time.Time
+	lockedUntil time.Time
+}
+
+func (a *loginAttempt) expired(now time.Time) bool {
+	return now.Sub(a.windowStart) > loginLockoutWindow && now.After(a.lockedUntil)
+}
+
+// loginLimiter tracks failed login attempts per username, in memory, to
+// slow down credential guessing against one account. This app runs as a
+// single instance (the same constraint documented for matchmaking's
+// in-memory state in CLAUDE.md applies here), so in-memory is a deliberate
+// choice: no DB round-trip on every login attempt, no cleanup job to run -
+// at the cost of resetting on restart, which is an acceptable tradeoff for
+// this threat model.
+type loginLimiter struct {
+	mu       sync.Mutex
+	attempts map[string]*loginAttempt
+}
+
+func newLoginLimiter() *loginLimiter {
+	return &loginLimiter{attempts: make(map[string]*loginAttempt)}
+}
+
+// locked reports whether username is currently locked out.
+func (l *loginLimiter) locked(username string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	a, ok := l.attempts[username]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(a.lockedUntil)
+}
+
+// recordFailure records a failed attempt for username, locking it out once
+// it crosses maxFailedLoginAttempts within loginLockoutWindow. Also sweeps
+// fully-expired entries out of the map so it doesn't grow unbounded.
+func (l *loginLimiter) recordFailure(username string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+
+	for u, a := range l.attempts {
+		if a.expired(now) {
+			delete(l.attempts, u)
+		}
+	}
+
+	a, ok := l.attempts[username]
+	if !ok || now.Sub(a.windowStart) > loginLockoutWindow {
+		a = &loginAttempt{windowStart: now}
+		l.attempts[username] = a
+	}
+
+	a.count++
+	if a.count >= maxFailedLoginAttempts {
+		a.lockedUntil = now.Add(loginLockoutDuration)
+	}
+}
+
+// recordSuccess clears any tracked failures for username.
+func (l *loginLimiter) recordSuccess(username string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.attempts, username)
+}

--- a/be/handlers/loginLimiter_test.go
+++ b/be/handlers/loginLimiter_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoginLimiter_LocksOutAfterThreshold(t *testing.T) {
+	l := newLoginLimiter()
+
+	for i := 0; i < maxFailedLoginAttempts-1; i++ {
+		l.recordFailure("alice")
+		require.False(t, l.locked("alice"), "should not lock out before the threshold")
+	}
+
+	l.recordFailure("alice")
+	require.True(t, l.locked("alice"), "should lock out once the threshold is reached")
+}
+
+func TestLoginLimiter_TracksUsersIndependently(t *testing.T) {
+	l := newLoginLimiter()
+
+	for i := 0; i < maxFailedLoginAttempts; i++ {
+		l.recordFailure("alice")
+	}
+
+	require.True(t, l.locked("alice"))
+	require.False(t, l.locked("bob"), "a different username must not be affected")
+}
+
+func TestLoginLimiter_SuccessClearsFailures(t *testing.T) {
+	l := newLoginLimiter()
+
+	for i := 0; i < maxFailedLoginAttempts-1; i++ {
+		l.recordFailure("alice")
+	}
+
+	l.recordSuccess("alice")
+
+	l.recordFailure("alice")
+	require.False(t, l.locked("alice"), "a success should reset the failure count")
+}
+
+func TestLoginLimiter_UnlocksAfterLockoutDuration(t *testing.T) {
+	l := newLoginLimiter()
+
+	now := time.Now()
+	l.attempts["alice"] = &loginAttempt{
+		count:       maxFailedLoginAttempts,
+		windowStart: now.Add(-loginLockoutWindow / 2),
+		lockedUntil: now.Add(-time.Second), // already in the past
+	}
+
+	require.False(t, l.locked("alice"), "lockout should have expired")
+}

--- a/be/handlers/users.go
+++ b/be/handlers/users.go
@@ -33,17 +33,11 @@ type User struct {
 	Status   string `json:"status"`
 }
 
-// validateSignupInput returns a user-facing message if username/password
-// don't meet the signup requirements, or "" if they're valid. Login
-// deliberately does not use this - a login attempt against an existing
-// account (e.g. one seeded before these rules existed) must never be
-// rejected for being "too short".
-func validateSignupInput(username, password string) string {
+// validatePassword is shared by signup and change-password - login
+// deliberately does not use it, so an existing/seeded account is never
+// locked out for being "too short" by rules added after it was created.
+func validatePassword(password string) string {
 	switch {
-	case username == "":
-		return "Username is required."
-	case len(username) < minUsernameLen || len(username) > maxUsernameLen:
-		return "Username must be between 3 and 32 characters."
 	case password == "":
 		return "Password is required."
 	case len(password) < minPasswordLen:
@@ -52,6 +46,16 @@ func validateSignupInput(username, password string) string {
 		return "Password must be at most 72 characters."
 	}
 	return ""
+}
+
+func validateSignupInput(username, password string) string {
+	switch {
+	case username == "":
+		return "Username is required."
+	case len(username) < minUsernameLen || len(username) > maxUsernameLen:
+		return "Username must be between 3 and 32 characters."
+	}
+	return validatePassword(password)
 }
 
 func (d *Data) UserCreate(w http.ResponseWriter, r *http.Request) {
@@ -99,21 +103,13 @@ func (d *Data) UserCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := d.Sessions.Get(r, "session")
+	session, err := d.P.CreateSession(ctx, id, d.Sessions.TTL)
 	if err != nil {
-		log.Error().Err(err).Msg("error getting session")
+		log.Error().Err(err).Msg("error creating session")
 		writeJSONError(w, http.StatusInternalServerError, "Your account was created, but we couldn't sign you in automatically. Please log in.")
 		return
 	}
-
-	session.Values["userID"] = id
-	session.Values["authenticated"] = true
-	// saves cookie
-	if err := session.Save(r, w); err != nil {
-		log.Error().Err(err).Msg("error saving session on create")
-		writeJSONError(w, http.StatusInternalServerError, "Your account was created, but we couldn't sign you in automatically. Please log in.")
-		return
-	}
+	d.setSessionCookie(w, session.ID)
 
 	w.WriteHeader(http.StatusCreated)
 
@@ -137,6 +133,12 @@ func (d *Data) UserLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if d.LoginLimiter.locked(b.Username) {
+		log.Warn().Str("username", b.Username).Msg("login blocked: too many failed attempts")
+		writeJSONError(w, http.StatusTooManyRequests, "Too many failed attempts. Please try again in a few minutes.")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
 	defer cancel()
 
@@ -149,48 +151,108 @@ func (d *Data) UserLogin(w http.ResponseWriter, r *http.Request) {
 		} else {
 			log.Error().Err(err).Str("username", b.Username).Msg("error getting user")
 		}
+		d.LoginLimiter.recordFailure(b.Username)
 		writeJSONError(w, http.StatusUnauthorized, "Incorrect username or password.")
 		return
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(u.Password), []byte(b.Password)); err != nil {
 		log.Warn().Str("username", b.Username).Msg("login failed: password mismatch")
+		d.LoginLimiter.recordFailure(b.Username)
 		writeJSONError(w, http.StatusUnauthorized, "Incorrect username or password.")
 		return
 	}
 
-	session, err := d.Sessions.Get(r, "session")
+	session, err := d.P.CreateSession(ctx, u.ID, d.Sessions.TTL)
 	if err != nil {
-		log.Error().Err(err).Msg("error getting session")
+		log.Error().Err(err).Msg("error creating session")
 		writeJSONError(w, http.StatusInternalServerError, "Something went wrong. Please try again.")
 		return
 	}
+	d.setSessionCookie(w, session.ID)
 
-	session.Values["userID"] = u.ID
-	session.Values["authenticated"] = true
-	if err := session.Save(r, w); err != nil {
-		log.Error().Err(err).Msg("error saving session on login")
-		writeJSONError(w, http.StatusInternalServerError, "Something went wrong. Please try again.")
-		return
-	}
-
+	d.LoginLimiter.recordSuccess(b.Username)
 	log.Info().Str("username", u.Username).Msg("user authenticated")
 }
 
 // TODO: maybe move to its own file ?
 func (d *Data) UserLogout(w http.ResponseWriter, r *http.Request) {
-	session, err := d.Sessions.Get(r, "session")
+	if token := d.sessionToken(r); token != "" {
+		ctx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
+		defer cancel()
+
+		if err := d.P.DeleteSession(ctx, token); err != nil {
+			log.Error().Err(err).Msg("error deleting session")
+			// Still clear the cookie below even if the DB delete failed -
+			// logout should never visibly fail from the user's perspective.
+		}
+	}
+
+	d.clearSessionCookie(w)
+}
+
+type changePasswordRequest struct {
+	CurrentPassword string `json:"currentPassword"`
+	NewPassword     string `json:"newPassword"`
+}
+
+// ChangePassword requires the caller's current password (confirms it's
+// really them, not just someone with a live session) before accepting a new
+// one, then revokes every other session for this user - if a stolen
+// password is what prompted the change, this logs out whoever had it.
+func (d *Data) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	userID, ok := userIDFromContext(r)
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "You must be logged in.")
+		return
+	}
+
+	var req changePasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Error().Err(err).Msg("error decoding change-password request")
+		writeJSONError(w, http.StatusBadRequest, "Invalid request.")
+		return
+	}
+
+	if msg := validatePassword(req.NewPassword); msg != "" {
+		writeJSONError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), dbQueryTimeout)
+	defer cancel()
+
+	user, err := d.P.GetUserByID(ctx, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("error getting session")
+		log.Error().Err(err).Int("userID", userID).Msg("error getting user for password change")
 		writeJSONError(w, http.StatusInternalServerError, "Something went wrong. Please try again.")
 		return
 	}
 
-	session.Values["authenticated"] = false
-	session.Options.MaxAge = -1
-	if err := session.Save(r, w); err != nil {
-		log.Error().Err(err).Msg("error saving session on logout")
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.CurrentPassword)); err != nil {
+		log.Warn().Int("userID", userID).Msg("change-password failed: current password mismatch")
+		writeJSONError(w, http.StatusUnauthorized, "Current password is incorrect.")
+		return
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
+	if err != nil {
+		log.Error().Err(err).Msg("error hashing new password")
 		writeJSONError(w, http.StatusInternalServerError, "Something went wrong. Please try again.")
 		return
 	}
+
+	if err := d.P.UpdateUserPassword(ctx, userID, string(hashedPassword)); err != nil {
+		log.Error().Err(err).Int("userID", userID).Msg("error updating password")
+		writeJSONError(w, http.StatusInternalServerError, "Something went wrong. Please try again.")
+		return
+	}
+
+	if currentToken := d.sessionToken(r); currentToken != "" {
+		if err := d.P.DeleteOtherSessions(ctx, userID, currentToken); err != nil {
+			log.Error().Err(err).Int("userID", userID).Msg("error revoking other sessions")
+		}
+	}
+
+	log.Info().Int("userID", userID).Msg("password changed")
 }

--- a/be/infra/envs/local/.env
+++ b/be/infra/envs/local/.env
@@ -3,4 +3,3 @@ DB_PASSWORD=root_password
 DB_HOST=localhost:3306
 DB_NAME=mishis4x
 ENV=local
-SESSION_SECRET=5c0d94274b26c1f78323dfd9e8de64cea15ed02ce8cdf2ae087a0f6e54d4dc50

--- a/be/infra/envs/local/.env.example
+++ b/be/infra/envs/local/.env.example
@@ -9,10 +9,3 @@ DB_PASSWORD=root_password
 DB_HOST=localhost:3306
 DB_NAME=mishis4x
 ENV=local
-
-# Signs (and, with a second key, would encrypt) the session cookie - anyone
-# who has it can forge a valid login for any user. This value is fine for
-# local/test ONLY (be/cmd/http.go refuses to accept it for any other --env);
-# for a real deployment, generate your own with `openssl rand -hex 32` and
-# set it as a real environment variable, never commit it.
-SESSION_SECRET=5c0d94274b26c1f78323dfd9e8de64cea15ed02ce8cdf2ae087a0f6e54d4dc50

--- a/be/persist/persist.go
+++ b/be/persist/persist.go
@@ -49,6 +49,11 @@ func NewDB(env string) (*sql.DB, error) {
 		Addr:                 dbHost,
 		DBName:               dbName,
 		AllowNativePasswords: true,
+		// Without this, the driver scans DATETIME/TIMESTAMP columns as raw
+		// []byte instead of time.Time - fine as long as nothing scans into a
+		// time.Time field, which stopped being true once sessions.expires_at
+		// showed up.
+		ParseTime: true,
 	}
 
 	db, err := sql.Open("mysql", cfg.FormatDSN())

--- a/be/persist/sessions.go
+++ b/be/persist/sessions.go
@@ -1,0 +1,94 @@
+package persist
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"errors"
+	"time"
+)
+
+// ErrSessionNotFound is returned by GetSession when the token doesn't match
+// any row, or matches one that's expired (an expired session is treated
+// identically to a nonexistent one - callers don't need to distinguish).
+var ErrSessionNotFound = errors.New("session not found")
+
+type Session struct {
+	ID        string
+	UserID    int
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// NewSessionToken generates a random, URL-safe session token: 32 bytes
+// (256 bits) from crypto/rand. This token IS the credential - unlike a
+// signed cookie, nothing verifies it cryptographically, its own entropy
+// (infeasible to guess) plus the server-side row lookup is what secures it.
+func NewSessionToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// CreateSession generates a new session token for userID and persists it,
+// valid for ttl.
+func (p *Persist) CreateSession(ctx context.Context, userID int, ttl time.Duration) (Session, error) {
+	token, err := NewSessionToken()
+	if err != nil {
+		return Session{}, err
+	}
+
+	s := Session{
+		ID:        token,
+		UserID:    userID,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+
+	q := `INSERT INTO sessions (id, user_id, expires_at) VALUES (?, ?, ?);`
+	if _, err := p.DB.ExecContext(ctx, q, s.ID, s.UserID, s.ExpiresAt); err != nil {
+		return Session{}, err
+	}
+
+	return s, nil
+}
+
+// GetSession looks up a session by its token. Returns ErrSessionNotFound if
+// the token doesn't exist or has expired.
+func (p *Persist) GetSession(ctx context.Context, token string) (Session, error) {
+	q := `SELECT id, user_id, created_at, expires_at FROM sessions WHERE id = ?;`
+
+	var s Session
+	err := p.DB.QueryRowContext(ctx, q, token).Scan(&s.ID, &s.UserID, &s.CreatedAt, &s.ExpiresAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Session{}, ErrSessionNotFound
+		}
+		return Session{}, err
+	}
+
+	if time.Now().After(s.ExpiresAt) {
+		return Session{}, ErrSessionNotFound
+	}
+
+	return s, nil
+}
+
+// DeleteSession removes a session by token - this is what makes logout an
+// actual server-side revocation instead of just clearing a client cookie.
+func (p *Persist) DeleteSession(ctx context.Context, token string) error {
+	_, err := p.DB.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?;`, token)
+	return err
+}
+
+// DeleteOtherSessions removes every session for userID except keepToken.
+// Used on password change: any other logged-in session (e.g. a device you
+// no longer trust) gets kicked out, while the session making the change
+// stays valid.
+func (p *Persist) DeleteOtherSessions(ctx context.Context, userID int, keepToken string) error {
+	q := `DELETE FROM sessions WHERE user_id = ? AND id != ?;`
+	_, err := p.DB.ExecContext(ctx, q, userID, keepToken)
+	return err
+}

--- a/be/persist/sessions_test.go
+++ b/be/persist/sessions_test.go
@@ -1,0 +1,97 @@
+package persist
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionLifecycle(t *testing.T) {
+	db := testDB(t)
+	p := &Persist{DB: db}
+
+	username := fmt.Sprintf("session-test-user-%d", os.Getpid())
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM users WHERE username = ?", username)
+	})
+
+	userID, err := p.CreateUser(t.Context(), User{Username: username, Status: "active", Password: "hashedpw"})
+	require.NoError(t, err)
+
+	session, err := p.CreateSession(t.Context(), userID, time.Hour)
+	require.NoError(t, err)
+	require.NotEmpty(t, session.ID)
+	require.Equal(t, userID, session.UserID)
+
+	fetched, err := p.GetSession(t.Context(), session.ID)
+	require.NoError(t, err)
+	require.Equal(t, session.ID, fetched.ID)
+	require.Equal(t, userID, fetched.UserID)
+
+	require.NoError(t, p.DeleteSession(t.Context(), session.ID))
+
+	_, err = p.GetSession(t.Context(), session.ID)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestSession_Expired(t *testing.T) {
+	db := testDB(t)
+	p := &Persist{DB: db}
+
+	username := fmt.Sprintf("session-expiry-test-user-%d", os.Getpid())
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM users WHERE username = ?", username)
+	})
+
+	userID, err := p.CreateUser(t.Context(), User{Username: username, Status: "active", Password: "hashedpw"})
+	require.NoError(t, err)
+
+	// A negative TTL creates a session that's already expired.
+	session, err := p.CreateSession(t.Context(), userID, -time.Hour)
+	require.NoError(t, err)
+
+	_, err = p.GetSession(t.Context(), session.ID)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestSession_NotFound(t *testing.T) {
+	db := testDB(t)
+	p := &Persist{DB: db}
+
+	_, err := p.GetSession(t.Context(), "does-not-exist")
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestDeleteOtherSessions(t *testing.T) {
+	db := testDB(t)
+	p := &Persist{DB: db}
+
+	username := fmt.Sprintf("session-revoke-test-user-%d", os.Getpid())
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM users WHERE username = ?", username)
+	})
+
+	userID, err := p.CreateUser(t.Context(), User{Username: username, Status: "active", Password: "hashedpw"})
+	require.NoError(t, err)
+
+	keep, err := p.CreateSession(t.Context(), userID, time.Hour)
+	require.NoError(t, err)
+	other1, err := p.CreateSession(t.Context(), userID, time.Hour)
+	require.NoError(t, err)
+	other2, err := p.CreateSession(t.Context(), userID, time.Hour)
+	require.NoError(t, err)
+
+	require.NoError(t, p.DeleteOtherSessions(t.Context(), userID, keep.ID))
+
+	_, err = p.GetSession(t.Context(), keep.ID)
+	require.NoError(t, err, "the session passed as keepToken must survive")
+
+	_, err = p.GetSession(t.Context(), other1.ID)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+
+	_, err = p.GetSession(t.Context(), other2.ID)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}

--- a/be/persist/users.go
+++ b/be/persist/users.go
@@ -103,3 +103,12 @@ func (p *Persist) GetUserByUsername(ctx context.Context, username string) (User,
 
 	return u, nil
 }
+
+// UpdateUserPassword replaces userID's stored password hash. Callers must
+// have already hashed newPassword (this function never sees plaintext) and
+// verified the caller's identity - it does not.
+func (p *Persist) UpdateUserPassword(ctx context.Context, userID int, hashedPassword string) error {
+	q := `UPDATE users SET password = ? WHERE id = ?;`
+	_, err := p.DB.ExecContext(ctx, q, hashedPassword, userID)
+	return err
+}

--- a/be/persist/users_test.go
+++ b/be/persist/users_test.go
@@ -30,6 +30,7 @@ func testDB(t *testing.T) *sql.DB {
 		Addr:                 host,
 		DBName:               envOr("DB_NAME", "mishis4x"),
 		AllowNativePasswords: true,
+		ParseTime:            true,
 	}
 
 	db, err := sql.Open("mysql", cfg.FormatDSN())

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,11 +53,5 @@ services:
       DB_USERNAME: root
       DB_PASSWORD: root_password
       DB_NAME: mishis4x
-      # Dockerfile runs with --env prod, so be/cmd/http.go's loadSessionSecret
-      # refuses the infra/envs/local/.env placeholder here - this needs its
-      # own value. Still just a local-compose-testing placeholder, not a real
-      # deploy secret; a real deployment must set its own via that platform's
-      # actual secrets mechanism, not a committed compose file.
-      SESSION_SECRET: 7217646d7dd36b3912b7aa07dc6f151c8eea178a98db997c18d60d5af863ff45
     ports:
       - "8091:8091"

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -3,6 +3,7 @@ import { GlobalDataProvider } from './GlobalDataContext';
 import Login from './components/Login.tsx';
 import Signup from './components/Signup.tsx';
 import Home from './components/Home.tsx';
+import ChangePassword from './components/ChangePassword.tsx';
 import Layout from './components/Layout';
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/login" element={<Login />} />
             <Route path="/sign-up" element={<Signup />} />
+            <Route path="/account" element={<ChangePassword />} />
           </Route>
         </Routes>
       </GlobalDataProvider>

--- a/fe/src/components/ChangePassword.tsx
+++ b/fe/src/components/ChangePassword.tsx
@@ -1,0 +1,99 @@
+import { FC, FormEvent, useState } from 'react';
+import Button from './ui/Button';
+import styles from './AuthPage.module.css';
+import formStyles from './UserForm.module.css';
+
+// Not built on UserForm - that component is specifically username+password
+// shaped for login/signup. This is a one-off current+new password form, not
+// worth forcing into a shared shape for.
+const ChangePassword: FC = () => {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(false);
+    setPending(true);
+
+    const form = event.currentTarget;
+    const target = form as typeof form & {
+      currentPassword: { value: string };
+      newPassword: { value: string };
+    };
+
+    fetch('/api/user/password', {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        currentPassword: target.currentPassword.value,
+        newPassword: target.newPassword.value,
+      }),
+    })
+      .then(async (res) => {
+        if (res.status === 200) {
+          setSuccess(true);
+          form.reset();
+          return;
+        }
+
+        const body = await res.json().catch(() => null);
+        setError(body?.error ?? 'Something went wrong. Please try again.');
+      })
+      .catch(() => {
+        setError('Could not reach the server. Please try again.');
+      })
+      .finally(() => setPending(false));
+  };
+
+  return (
+    <div className={styles.page}>
+      <h1>Change password</h1>
+      <form onSubmit={handleSubmit} className={formStyles.form}>
+        {error && (
+          <p className={formStyles.error} role="alert">
+            {error}
+          </p>
+        )}
+        {success && (
+          <p className={formStyles.success} role="status">
+            Password updated. Other devices you were logged in on have been
+            signed out.
+          </p>
+        )}
+        <div className={formStyles.field}>
+          <label htmlFor="currentPassword">Current password</label>
+          <input
+            type="password"
+            name="currentPassword"
+            id="currentPassword"
+            autoComplete="current-password"
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className={formStyles.field}>
+          <label htmlFor="newPassword">New password</label>
+          <input
+            type="password"
+            name="newPassword"
+            id="newPassword"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            disabled={pending}
+          />
+        </div>
+
+        <Button type="submit" disabled={pending}>
+          {pending ? 'Updating…' : 'Update password'}
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default ChangePassword;

--- a/fe/src/components/Navigation.tsx
+++ b/fe/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useContext } from 'react';
 import { GlobalDataContext } from '../GlobalDataContext';
 import Button from './ui/Button';
@@ -42,6 +42,9 @@ const Navigation = () => {
           <ul className={styles.userMenu}>
             <li className={styles.greeting}>
               Hello, <strong>{globalData.user.username}</strong>
+            </li>
+            <li>
+              <Link to="/account">Account</Link>
             </li>
             <li>
               <Button variant="danger" onClick={handleLogout}>

--- a/fe/src/components/UserForm.module.css
+++ b/fe/src/components/UserForm.module.css
@@ -24,3 +24,9 @@
   font-size: var(--text-sm);
   margin: 0;
 }
+
+.success {
+  color: var(--good);
+  font-size: var(--text-sm);
+  margin: 0;
+}


### PR DESCRIPTION
Three pieces, requested together since they interact:

## Server-side sessions (replaces gorilla/sessions entirely)

The session cookie used to be a self-contained signed blob - the whole session lived client-side, nothing server-side. "Logout" only cleared the client's cookie; a leaked session token stayed valid for its full 30-day life regardless. Replaced with the standard pattern: login/ signup issue a random opaque token (persist.NewSessionToken, 256 bits from crypto/rand) stored in a new `sessions` table, and the cookie only ever carries that token. There's nothing to sign or encrypt - the token's own entropy plus the server-side row lookup is what authenticates a request - so SESSION_SECRET (added just last PR) is gone entirely, along with the gorilla/sessions dependency. Logout now does a real DELETE, not just a client-side cookie clear.

New: be/persist/sessions.go (CreateSession/GetSession/DeleteSession/ DeleteOtherSessions), migration 11092023_5 for the `sessions` table, AuthMiddleware rewritten to look up the token and attach userID to the request context instead of gorilla's session.Values.

Caught a real latent bug along the way: the MySQL DSN never set ParseTime, so scanning sessions.expires_at into a time.Time failed outright - go-sql-driver returns DATETIME/TIMESTAMP as raw []byte without it. Nothing had scanned into time.Time before, so this was invisible until now. Fixed in persist.NewDB and the test DB helper.

## Rate limiting on login

Unlimited password guesses were possible against any username. Added an in-memory (see loginLimiter.go for why in-memory is deliberate, not a shortcut, given this runs as a single instance) limiter: 5 failed attempts per username within 15 minutes locks that username out for 5 minutes. Failures are recorded for both "wrong password" and "no such user" identically, so the limiter itself can't be used to enumerate usernames either.

## Change password

There was no way to ever change a password once an account existed. Added POST /api/user/password (protected route): requires the current password, validates the new one with the same rules as signup, and - now that sessions are revocable - deletes every other session for that user on success, so a device you no longer trust gets logged out the moment you change your password. New /account page on the frontend, linked from the nav.

Verified: go build/vet/test pass (new sessions_test.go and loginLimiter_test.go included), golangci-lint 0 issues, fe typecheck/ lint/prettier/build all pass. Extensively verified live against a real MySQL container via curl: signup, an authenticated request, logout, then replaying the EXACT same pre-logout token to confirm it was actually revoked server-side (not just client-side) - 401 as expected. Rate limiting confirmed: 5 wrong-password attempts, 6th returns 429. Change-password confirmed end-to-end: opened two sessions for one user, changed the password using session A, verified session A stayed valid, session B was revoked, the old password stopped working, and the new one worked. Also checked the new /account UI in a real browser (success/error states render correctly) and ran the full docker-compose + Playwright suite twice (once before, once after these changes) to confirm the seeded test/test login still works end-to-end through the new mechanism.