### PR TITLE
be: support TLS for managed MySQL providers (DigitalOcean, etc.)

### DIFF
--- a/be/persist/persist.go
+++ b/be/persist/persist.go
@@ -2,7 +2,11 @@ package persist
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -16,6 +20,10 @@ import (
 // reachable at startup. sql.Open never dials on its own - without this ping,
 // an unreachable DB would only surface on the first real query.
 const connectTimeout = 5 * time.Second
+
+// tlsConfigName is the name configureTLS registers with the mysql driver
+// for a CA-verified TLS connection - see configureTLS.
+const tlsConfigName = "managed-mysql"
 
 type Persist struct {
 	DB *sql.DB
@@ -56,6 +64,10 @@ func NewDB(env string) (*sql.DB, error) {
 		ParseTime: true,
 	}
 
+	if err := configureTLS(&cfg); err != nil {
+		return nil, fmt.Errorf("configuring db TLS: %w", err)
+	}
+
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, err
@@ -69,4 +81,33 @@ func NewDB(env string) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// configureTLS registers a custom TLS config trusting DB_CA_CERT (a base64-
+// encoded PEM certificate) and points cfg at it, if DB_CA_CERT is set. Local/
+// test's plain Docker MySQL has no TLS at all, so DB_CA_CERT is simply unset
+// there and this is a no-op - only managed providers that require TLS with
+// their own CA (DigitalOcean Managed Databases, etc.) need it set.
+func configureTLS(cfg *mysql.Config) error {
+	encoded := os.Getenv("DB_CA_CERT")
+	if encoded == "" {
+		return nil
+	}
+
+	pemBytes, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("DB_CA_CERT is not valid base64: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(pemBytes); !ok {
+		return errors.New("DB_CA_CERT does not contain a valid PEM certificate")
+	}
+
+	if err := mysql.RegisterTLSConfig(tlsConfigName, &tls.Config{RootCAs: pool}); err != nil {
+		return fmt.Errorf("registering TLS config: %w", err)
+	}
+
+	cfg.TLSConfig = tlsConfigName
+	return nil
 }


### PR DESCRIPTION
Managed MySQL providers require TLS and use their own CA - connecting without this would fail outright the moment we point this at a real managed database (DigitalOcean's, in particular, since that's what we're deploying to). persist.NewDB previously configured no TLS at all, which only ever worked because local/CI use a throwaway Docker MySQL with no TLS required.

Added configureTLS: if DB_CA_CERT (a base64-encoded PEM certificate) is set, it's decoded, parsed, and registered with the mysql driver as a trusted CA for the connection. If it's unset - true for local/test, where Docker MySQL has no TLS at all - this is a no-op and behavior is unchanged. Only managed providers that require TLS with their own CA need this set at all.

Verified: go build/vet/test pass, golangci-lint 0 issues, full test suite green against a throwaway Docker MySQL (DB_CA_CERT unset, confirming zero regression for local/CI).

Also did a real, rigorous TLS test rather than just trusting the code compiles - generated an actual CA + server certificate pair (not relying on MySQL's auto-generated dev cert, which isn't meant for strict hostname verification and would have given a false negative), configured a real MySQL instance to require secure transport with it, and confirmed all three cases behave correctly:
  - no DB_CA_CERT set -> server rejects the connection outright ("Connections using insecure transport are prohibited")
  - wrong CA cert set -> client rejects it ("certificate signed by unknown authority")
  - correct CA cert set -> connects and runs migrations successfully